### PR TITLE
Set debug to default false if env is missing

### DIFF
--- a/config/app.default.php
+++ b/config/app.default.php
@@ -9,7 +9,7 @@ return [
      * Development Mode:
      * true: Errors and warnings shown.
      */
-    'debug' => filter_var(env('DEBUG', true), FILTER_VALIDATE_BOOLEAN),
+    'debug' => filter_var(env('DEBUG'), FILTER_VALIDATE_BOOLEAN),
 
     /**
      * Configure basic information about the application.


### PR DESCRIPTION
To avoid errors in production debug should be defaulted to false if env-var is missing. FILTER_VALIDATE_BOOLEAN will set false if env('DEBUG') is null.
