### PR TITLE
Optionally set fullBaseUrl with env-var

### DIFF
--- a/config/app.default.php
+++ b/config/app.default.php
@@ -45,7 +45,7 @@ return [
         'webroot' => 'webroot',
         'wwwRoot' => WWW_ROOT,
         // 'baseUrl' => env('SCRIPT_NAME'),
-        'fullBaseUrl' => false,
+        'fullBaseUrl' => env('APP_FULLBASEURL', false),
         'imageBaseUrl' => 'img/',
         'cssBaseUrl' => 'css/',
         'jsBaseUrl' => 'js/',


### PR DESCRIPTION
Makes sense to set fullBaseUrl with same env-variable as env.php uses.
