### PR TITLE
Updated composer.json to to fix errors on PHP 7.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,6 @@ before_install:
   - if [[ $TRAVIS_PHP_VERSION != 'hhvm' ]] ; then echo 'extension = redis.so' >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini; fi
   - if [[ $TRAVIS_PHP_VERSION != 'hhvm' ]] ; then echo 'extension = apcu.so' >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini; fi
   - if [[ $TRAVIS_PHP_VERSION != 'hhvm' ]] ; then echo 'apc.enable_cli = 1' >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini; fi
-  - if [[ $TRAVIS_PHP_VERSION = 7.0 ]] ; then echo yes | pecl install channel://pecl.php.net/apcu-5.1.5; fi
   - phpenv rehash
   - set +H
 

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "cakephp/migrations": "~1.0",
         "cakephp/plugin-installer": "~1.0",
         "josegonzalez/dotenv": "2.*",
-        "friendsofcake/crud": "4.*",
+        "friendsofcake/crud": "^5.0",
         "friendsofcake/crud-view": "0.*",
         "friendsofcake/bootstrap-ui": "0.*",
         "friendsofcake/search": "1.*",


### PR DESCRIPTION
As per [this bug](https://github.com/FriendsOfCake/crud/issues/565) using `friendsofcake/crud` version 4 returns a fatal error when using PHP 7.2. The fix is to set the `friendsofcake/crud` to version 5.