### PR TITLE
fix: remove deprecated functionc calls

### DIFF
--- a/config/bootstrap.php
+++ b/config/bootstrap.php
@@ -206,7 +206,7 @@ if (Configure::read('debug')) {
 
 // Handle the CakeQueuesadilla
 Plugin::load('Josegonzalez/CakeQueuesadilla');
-\Josegonzalez\CakeQueuesadilla\Queue\Queue::config(Configure::consume('Queuesadilla'));
+\Josegonzalez\CakeQueuesadilla\Queue\Queue::setConfig(Configure::consume('Queuesadilla'));
 
 Plugin::load('AssetCompress', ['bootstrap' => true]);
 Plugin::load('BootstrapUI');

--- a/config/routes.php
+++ b/config/routes.php
@@ -47,7 +47,7 @@ use Cake\Routing\Route\DashedRoute;
 Router::defaultRouteClass(DashedRoute::class);
 
 Router::scope('/', function (RouteBuilder $routes) {
-    $routes->extensions(['json']);
+    $routes->setExtensions(['json']);
 
     /**
      * Here, we are connecting '/' (base path) to a controller called 'Pages',

--- a/src/Controller/AppController.php
+++ b/src/Controller/AppController.php
@@ -100,11 +100,11 @@ class AppController extends Controller
             ],
         ]);
 
-        if ($this->isAdmin || in_array($this->request->action, $this->adminActions)) {
+        if ($this->isAdmin || in_array($this->request->getParam('action'), $this->adminActions)) {
             $this->Crud->addListener('CrudView.View');
         }
 
-        if (in_array($this->request->action, $this->searchActions) && $this->modelClass !== null) {
+        if (in_array($this->request->getParam('action'), $this->searchActions) && $this->modelClass !== null) {
             list($plugin, $tableClass) = pluginSplit($this->modelClass);
             try {
                 if ($this->$tableClass->behaviors()->hasMethod('filterParams')) {
@@ -156,8 +156,8 @@ class AppController extends Controller
             }
         }
 
-        $isRest = in_array($this->response->type(), ['application/json', 'application/xml']);
-        $isAdmin = $this->isAdmin || in_array($this->request->action, $this->adminActions);
+        $isRest = in_array($this->response->getType(), ['application/json', 'application/xml']);
+        $isAdmin = $this->isAdmin || in_array($this->request->getParam('action'), $this->adminActions);
         if (!$isRest && $isAdmin && empty($this->request->getParam('_ext'))) {
             $this->viewBuilder()->className('CrudView\View\CrudView');
         }


### PR DESCRIPTION
**PLEASE NOTE:**

This is only a issue tracker for issues related to the CakePHP Application Skeleton.
For CakePHP Framework issues please use this [issue tracker](https://github.com/cakephp/cakephp/issues).

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

The best way to propose a feature is to open an issue first and discuss your ideas there before implementing them.

Always follow the [contribution guidelines](https://github.com/cakephp/cakephp/blob/master/.github/CONTRIBUTING.md) guidelines when submitting a pull request. In particular, make sure existing tests still pass, and add tests for all new behavior. When fixing a bug, you may want to add a test to verify the fix.